### PR TITLE
Login to Docker before creating manifest

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,14 +21,15 @@ jobs:
       shell: bash
       run: |
         docker pull golang:${{ matrix.version }}
+    - name: login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: push
       shell: bash
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
         docker tag golang:${{ matrix.version }} antrea/golang:${{ runner.os }}-${{ matrix.version }}
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/golang:${{ runner.os }}-${{ matrix.version }}
   manifest:
     runs-on: [ubuntu-latest]
@@ -39,13 +40,17 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
+    - name: info
+      run: |
+        docker version
+    - name: login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: create
       run: |
         docker manifest create antrea/golang:${{ matrix.version }} antrea/golang:Linux-${{ matrix.version }} antrea/golang:Windows-${{ matrix.version }}
     - name: push
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest push antrea/golang:${{ matrix.version }}


### PR DESCRIPTION
The "docker manifest create" is failing when not logged in. Not clear whether this was an intentional change or a temporary bug. To avoid the issue, we use docker/login-action to login before creating the manifest.